### PR TITLE
Make sure package ids are munged

### DIFF
--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -253,8 +253,8 @@ class OaipmhHarvester(HarvesterBase):
             content = json.loads(harvest_object.content)
             log.debug(content)
 
-            package_dict['id'] = harvest_object.guid
-            package_dict['name'] = munge_title_to_name(harvest_object.guid)
+            package_dict['id'] = munge_title_to_name(harvest_object.guid)
+            package_dict['name'] = package_dict['id']
 
             mapping = self._get_mapping()
 


### PR DESCRIPTION
CKAN does not allow IDs to be URLs if you want to harvest them, so let's
make sure, that we don't break things upfront and then can't harvest
datasets anymore.