### PR TITLE
Updating _create_or_update_package() method for CKAN 2.8 support

### DIFF
--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -339,7 +339,8 @@ class OaipmhHarvester(HarvesterBase):
             log.debug('Create/update package using dict: %s' % package_dict)
             self._create_or_update_package(
                 package_dict,
-                harvest_object
+                harvest_object,
+                'package_show'
             )
 
             Session.commit()


### PR DESCRIPTION
Hi @metaodi,

I updated the _create_or_update_package() method that is used in your harvester from the original harvester class, because CKAN 2.8 don't have "package_update_rest" action in it, as a result, it throws an error, but I found a workaround so it works.